### PR TITLE
:goal_net: Notify users if the parsing of a feed failed repeatedly

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -45,10 +45,6 @@
   ],
   "servers": [
     {
-      "url": "https://b2-backend.vwprg.mylab.th-luebeck.de/v1",
-      "description": "Production server"
-    },
-    {
       "url": "{protocol}://{host}:{port}/{endpoint}",
       "description": "Development server",
       "variables": {
@@ -69,6 +65,10 @@
           "default": "v1"
         }
       }
+    },
+    {
+      "url": "https://backend.rsswipe.mcloud.digital/v1",
+      "description": "Production server"
     }
   ],
   "paths": {
@@ -1412,6 +1412,14 @@
           "lang": {
             "type": "string",
             "description": "content language"
+          },
+          "errormessage": {
+            "type": "string",
+            "description": "the error message if there was an error parsing the feed"
+          },
+          "error_count": {
+            "type": "number",
+            "description": "the number of times the parsing of the feed failed since the last success"
           }
         }
       },

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1412,14 +1412,6 @@
           "lang": {
             "type": "string",
             "description": "content language"
-          },
-          "errormessage": {
-            "type": "string",
-            "description": "the error message if there was an error parsing the feed"
-          },
-          "error_count": {
-            "type": "number",
-            "description": "the number of times the parsing of the feed failed since the last success"
           }
         }
       },
@@ -1461,6 +1453,14 @@
           },
           "openInApp": {
             "type": "boolean"
+          },
+          "errormessage": {
+            "type": "string",
+            "description": "the error message if there was an error parsing the feed"
+          },
+          "error_count": {
+            "type": "number",
+            "description": "the number of times the parsing of the feed failed since the last success"
           }
         }
       },

--- a/backend/prisma/migrations/20240124150210_add_error_to_feed/migration.sql
+++ b/backend/prisma/migrations/20240124150210_add_error_to_feed/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `Feed` ADD COLUMN `error_count` INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN `errormessage` VARCHAR(191) NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,15 +22,17 @@ model User {
 }
 
 model Feed {
-  id          String     @id @default(uuid())
-  title       String
-  link        String     @unique @db.VarChar(1000)
-  createdAt   DateTime   @default(now())
-  faviconUrl  String?    @db.VarChar(1000)
-  lastUpdate  DateTime   @default(now())
-  active      Boolean    @default(true)
-  UserHasFeed FeedList[]
-  Article     Article[]
+  id           String     @id @default(uuid())
+  title        String
+  link         String     @unique @db.VarChar(1000)
+  createdAt    DateTime   @default(now())
+  faviconUrl   String?    @db.VarChar(1000)
+  lastUpdate   DateTime   @default(now())
+  active       Boolean    @default(true)
+  errormessage String?
+  error_count  Int        @default(0)
+  UserHasFeed  FeedList[]
+  Article      Article[]
 }
 
 model FeedList {

--- a/backend/src/helper/environment.ts
+++ b/backend/src/helper/environment.ts
@@ -18,5 +18,6 @@ export const environment = {
     garbageCollectorInterval: constructEnv("GARBAGE_COLLECTOR_INTERVAL", (1000 * 60 * 60 * 1).toString()),
     maxUrlLength: constructEnv("MAX_URL_LENGTH", "1000"), // Default size for all urls
     maxImageUrlLength: constructEnv("MAX_IMAGE_URL_LENGTH", "10000"), // Sometimes, image urls can be stored in an optimized format, which can be longer than the other urls
+    maxFeedErrorCount: constructEnv("MAX_FEED_ERROR_COUNT", "20"), // If a feed has more than 20 errors, it will be disabled. Currently it is __not possible__ to re-enable a feed
 };
 

--- a/backend/src/helper/environment.ts
+++ b/backend/src/helper/environment.ts
@@ -10,11 +10,6 @@ export const environment = {
     // TO DEFINE THE DEFAULT SECRETS HERE IS BAD PRACTICE!!! 
     jwtSecret: constructEnv("JWT_SECRET"),
     jwtExpiration: constructEnv("JWT_EXPIRATION", "30d"),
-    // dbHost: constructEnv("DB_HOST"),
-    // dbPort: constructEnv("DB_PORT"),
-    // dbDatabase: constructEnv("DB_DATABASE"),
-    // dbUser: constructEnv("DB_USER"),
-    // dbPassword: constructEnv("DB_PASSWORD"),
     dbUrl: constructEnv("DATABASE_URL"),
     status: constructEnv("STATUS", "production"),
     backendPort: constructEnv("BACKEND_PORT", "8080"),

--- a/backend/src/helper/environment.ts
+++ b/backend/src/helper/environment.ts
@@ -7,9 +7,8 @@ function constructEnv(name: string, defaultOption: string = ""): string {
 }
 
 export const environment = {
-    // TO DEFINE THE DEFAULT SECRETS HERE IS BAD PRACTICE!!! We only do that, 
-    // because we don't have access to the secret management in deployment
-    jwtSecret: constructEnv("JWT_SECRET", "secret"),
+    // TO DEFINE THE DEFAULT SECRETS HERE IS BAD PRACTICE!!! 
+    jwtSecret: constructEnv("JWT_SECRET"),
     jwtExpiration: constructEnv("JWT_EXPIRATION", "30d"),
     // dbHost: constructEnv("DB_HOST"),
     // dbPort: constructEnv("DB_PORT"),

--- a/backend/src/helper/feedParsing.ts
+++ b/backend/src/helper/feedParsing.ts
@@ -16,8 +16,8 @@ export function parseFeedFromUrl(feedUrl: string): Promise<ParsedFeed> {
                 const feedparser = new FeedParser({});
                 const items: FeedParser.Item[] = [];
 
-                if (res.status != 200) {
-                    return reject(new Error('Bad status code'));
+                if (res.status < 200 || res.status >= 300) {
+                    return reject(new Error('Bad status code: ' + res.status));
                 }
 
                 responseStream.pipe(feedparser);

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -2,6 +2,23 @@
 @import './base.css';
 @import './transitions.css';
 
+.error-dot::after {
+  @apply bg-red-500;
+  content: '';
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  transform: scale(0);
+  transition: transform 0.3s ease;
+}
+
+.error-dot-active::after {
+  display: block;
+  transform: scale(1);
+}
 
 @layer base {
   :root {
@@ -26,18 +43,16 @@
     @apply text-white;
   }
   ::selection {
-    @apply bg-primary-600
+    @apply bg-primary-600;
   }
 
   /* For Gecko-basierte Browser wie Firefox */
   ::-moz-selection {
-    @apply bg-primary-600
+    @apply bg-primary-600;
   }
 }
 
-
 @layer utilities {
-
   /* Hide scrollbar for Chrome, Safari and Opera */
   .no-scrollbar::-webkit-scrollbar {
     display: none;

--- a/frontend/src/components/feeds/feedPage/FeedPageItem.vue
+++ b/frontend/src/components/feeds/feedPage/FeedPageItem.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
 import { computed, ref, onMounted } from 'vue';
-import { useFeedStore } from '@/stores/feeds';
+import { FEED_ERROR_COUNT_THRESHOLD, useFeedStore } from '@/stores/feeds';
 import type { FeedItem } from '@/stores/feeds';
-import { ChevronDown } from 'lucide-vue-next';
+import { ChevronDown, Info } from 'lucide-vue-next';
 import { Trash2 } from 'lucide-vue-next';
+
+const REPORT_URL: string = "https://github.com/Importantus/RSSwipe";
 
 const props = defineProps<{
     feed: FeedItem;
 }>();
 
 const store = useFeedStore();
+const isErroneous = computed(() => props.feed.error_count > FEED_ERROR_COUNT_THRESHOLD);
 const showOptions = ref(false);
 const templateArr: string[] = [
     "/images/articles/placeholder01.png",
@@ -52,6 +55,9 @@ const openFeedPage = () => {
     const baseUrl = new URL(props.feed.url).origin
     window.open(baseUrl, '_blank');
 }
+
+console.log(props.feed);
+
 </script>
 
 <template>
@@ -59,7 +65,8 @@ const openFeedPage = () => {
         <div @click="toggleOptions" class="flex items-center text-left cursor-pointer relative z-10">
             <div
                 class="flex justify-between bg-[#222] text-white px-4 py-3 rounded-t-lg shadow-md w-full transition items-center gap-3">
-                <div class="w-10 h-10 flex-shrink-0 overflow-hidden rounded">
+                <div class="w-10 h-10 flex-shrink-0 overflow-hidden rounded error-dot relative"
+                    :class="{ 'error-dot-active': isErroneous }">
                     <img class="min-w-full min-h-full object-cover" :src="faviconUrl" alt="favicon" />
                 </div>
                 <div class="flex flex-col w-full overflow-hidden">
@@ -76,6 +83,16 @@ const openFeedPage = () => {
         <Transition name="slide-fade">
             <div v-if="showOptions" class="px-4 py-4 rounded-lg bg-[#282828] flex flex-col gap-4 z-0"
                 :class="{ 'rounded-t-none': showOptions }">
+                <div v-if="props.feed.errormessage">
+                    <div class="flex flex-row items-center gap-2 bg-red-800 rounded-t-lg px-3 py-2">
+                        <Info size="25"></Info>
+                        <p class="text-left font-thin text-sm">We failed to fetch this feed for {{
+                            props.feed.error_count }} times. Error messages related to the
+                            app can be reported <a class="underline" :href="REPORT_URL">here</a>.</p>
+                    </div>
+                    <p class="bg-red-500 rounded-b-lg px-3 py-2 z-10 text-sm">{{ props.feed.errormessage
+                    }}</p>
+                </div>
                 <div class="flex justify-between items-center gap-2">
                     <div>
                         <h3 class="font-semibold">Open in App?</h3>

--- a/frontend/src/components/home/navigation/HomeFeedsButton.vue
+++ b/frontend/src/components/home/navigation/HomeFeedsButton.vue
@@ -1,14 +1,20 @@
 <script setup lang="ts">
 import router from '@/router';
+import { useFeedStore } from '@/stores/feeds';
 import { Rss } from 'lucide-vue-next';
+import { ref } from 'vue';
 
 function openFeedSettings() {
     router.push({ name: 'Feeds' });
 }
+const store = useFeedStore();
+
+let someFeedHasError = ref<boolean>(store.someFeedHasError());
 </script>
 
 <template>
-    <button @click="openFeedSettings" title="Your Feed">
+    <button @click="openFeedSettings" title="Your Feed" class="relative error-dot"
+        :class="{ 'error-dot-active': someFeedHasError }">
         <Rss size="24" class=" text-white" />
     </button>
 </template>

--- a/frontend/src/components/home/navigation/HomeFeedsButton.vue
+++ b/frontend/src/components/home/navigation/HomeFeedsButton.vue
@@ -2,19 +2,17 @@
 import router from '@/router';
 import { useFeedStore } from '@/stores/feeds';
 import { Rss } from 'lucide-vue-next';
-import { ref } from 'vue';
 
 function openFeedSettings() {
     router.push({ name: 'Feeds' });
 }
 const store = useFeedStore();
 
-let someFeedHasError = ref<boolean>(store.someFeedHasError());
 </script>
 
 <template>
     <button @click="openFeedSettings" title="Your Feed" class="relative error-dot"
-        :class="{ 'error-dot-active': someFeedHasError }">
+        :class="{ 'error-dot-active': store.someFeedHasError() }">
         <Rss size="24" class=" text-white" />
     </button>
 </template>

--- a/frontend/src/stores/feeds.ts
+++ b/frontend/src/stores/feeds.ts
@@ -5,7 +5,8 @@ import { StoreStatus } from './readingList';
 
 
 // The threshold for the error count of a feed to be considered as broken
-export const FEED_ERROR_COUNT_THRESHOLD = 1
+// e.g. the notification will be shown if the error count is greater than this value
+export const FEED_ERROR_COUNT_THRESHOLD = 3;
 
 export interface FeedItem {
     id: string,


### PR DESCRIPTION
closes #12 

- Add an error message field to the feed more info section that gets expanded on the feed page.
- Add a notification "dot" on the home view next to the feed navigation item if any feed has an error.
- Add a notification "dot" next to the favicon of any feeds that have errors on the feed page.

The error notification will only be shown after a certain threshold of errors has been exceeded (currently 3). This is supposed to prevent users getting spammed with errors arising from small down-times some feeds may have.  
Error messages are always displayed if there are any. 

AND: 
- Additionally I refactored the env config a little bit.
- Added a default title for articles "No title set" (need for e.g. mastodon rss feeds)