### PR TITLE
Revert unique index

### DIFF
--- a/backend/prisma/migrations/20240311112857_make_article_link_and_feedid_unique/migration.sql
+++ b/backend/prisma/migrations/20240311112857_make_article_link_and_feedid_unique/migration.sql
@@ -1,8 +1,0 @@
-/*
-  Warnings:
-
-  - A unique constraint covering the columns `[link,feedId]` on the table `Article` will be added. If there are existing duplicate values, this will fail.
-
-*/
--- CreateIndex
-CREATE UNIQUE INDEX `Article_link_feedId_key` ON `Article`(`link`, `feedId`);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -59,8 +59,6 @@ model Article {
   feed           Feed          @relation(fields: [feedId], references: [id])
   categoryId     String?
   category       Category?     @relation(fields: [categoryId], references: [id], onDelete: SetNull)
-
-  @@unique([link, feedId])
 }
 
 model Settings {

--- a/backend/src/jobs/feedparser.ts
+++ b/backend/src/jobs/feedparser.ts
@@ -220,12 +220,10 @@ async function addArticlesToDb(articles: FeedParser.Item[], feedId: string) {
     let newArticles = 0;
 
     for (const article of articles) {
-        const existingArticle = await prisma.article.findUnique({
+        const existingArticle = await prisma.article.findFirst({
             where: {
-                link_feedId: {
-                    link: article.link,
-                    feedId: feedId
-                }
+                link: article.link,
+                feedId: feedId
             }
         });
 


### PR DESCRIPTION
The unique keyword creates an index over the specified columns. This limits the data that can be stored in those columns. 

This caused errors in existing deployments.  