### PR TITLE
:bug: Fix bug where rss feed parsing just stops

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -155,17 +155,9 @@ versions.forEach(version => {
 app.use(notFound);
 app.use(errorHandler);
 
-try {
-    initFeedParser();
-} catch (e) {
-    log("Error while parsing feeds: " + e, Scope.FEEDPARSER);
-}
+initFeedParser();
 
-try {
-    initGarbageCollector();
-} catch (e) {
-    log("Error while bringing out the trash: " + e, Scope.GARBAGE_COLLECTOR);
-}
+initGarbageCollector();
 
 app.listen(port, () => {
     log(`Server started at http://localhost:${port}`, Scope.API);

--- a/backend/src/jobs/feedparser.ts
+++ b/backend/src/jobs/feedparser.ts
@@ -367,13 +367,23 @@ Updating ${feeds.length} Feeds
  * @param intervall The intervall in ms to update the feeds
  */
 export async function initFeedParser(intervall = Number(environment.feedUpdateInterval)) {
-    log("Initializing Feed Parser with an intervall of " + intervall + "ms", Scope.FEEDPARSER);
-    let time = new Date().getTime();
-    while (true) {
-        await updateAllFeeds();
+    try {
+        log("Initializing Feed Parser with an intervall of " + intervall + "ms", Scope.FEEDPARSER);
+        let time = new Date().getTime();
+        while (true) {
+            try {
+                await updateAllFeeds();
+            } catch (error) {
+                log("Error while updating feeds: " + error, Scope.FEEDPARSER, Level.ERROR);
+            }
 
-        // Wait until intervall is over
-        await new Promise((resolve) => setTimeout(resolve, intervall - (new Date().getTime() - time)));
-        time = new Date().getTime();
+            // Wait until intervall is over
+            await new Promise((resolve) => setTimeout(resolve, intervall - (new Date().getTime() - time)));
+            time = new Date().getTime();
+        }
+    } catch (error) {
+        log("Error while parsing feeds: " + error, Scope.FEEDPARSER, Level.ERROR);
+        log("Feed parsing job failed. Attempting to restart...", Scope.FEEDPARSER);
+        initFeedParser(intervall);
     }
 }


### PR DESCRIPTION
closes #76 

We did not catch errors correctly which explains the absence of log messages. 

I added the catch and logging and implemented a restart mechanism when the parsing job failed.